### PR TITLE
Bug fix in CreateWindowsService task type of the Automatic service initialization (Delayed Start)

### DIFF
--- a/WinServices/CreateWindowsService/createservice.ps1
+++ b/WinServices/CreateWindowsService/createservice.ps1
@@ -28,6 +28,13 @@ if ($existingService)
 	Start-Sleep -s 5  
 }
 
+$startupTypeIsAutomaticDelayedStart = $startupType -eq "AutomaticDelayedStart"
+
+if ($startupTypeIsAutomaticDelayedStart) {
+
+	$startupType = "Automatic"	
+}
+
 if ($userType -eq "Custom") {
 	
 	$servicePassword = convertto-securestring -String $password -AsPlainText -Force  
@@ -41,6 +48,17 @@ if ($userType -eq "Custom") {
 	Write-Host "Installing the service with local system account."
 	New-Service -BinaryPathName "$exePath" -Name "$serviceName" -DisplayName "$displayName" -Description "$description" -StartupType $startupType 
 
+}
+
+if ($startupTypeIsAutomaticDelayedStart) {	
+
+	$Output = Invoke-Expression -Command "sc.exe config $serviceName start= delayed-auto" -ErrorAction Stop
+	
+	if($LASTEXITCODE -ne 0) {
+
+		Write-Error "Failed to set $serviceName to automatic delayed start.`r`n`t$Output"				
+		Exit $LASTEXITCODE
+	}
 }
 
 Write-Host "Installed the service."

--- a/WinServices/CreateWindowsService/task.json
+++ b/WinServices/CreateWindowsService/task.json
@@ -13,7 +13,7 @@
 	"version": {
 		"Major": "1",
 		"Minor": "1",
-		"Patch": "0"
+		"Patch": "1"
 	},
 	"minimumAgentVersion": "1.83.0",
 	"instanceNameFormat": "Create windows service $(serviceName)",

--- a/WinServices/Properties/AssemblyInfo.cs
+++ b/WinServices/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/WinServices/StartWindowsService/task.json
+++ b/WinServices/StartWindowsService/task.json
@@ -13,7 +13,7 @@
 	"version": {
 		"Major": "1",
 		"Minor": "1",
-		"Patch": "0"
+		"Patch": "1"
 	},
 	"minimumAgentVersion": "1.83.0",
 	"instanceNameFormat": "Start windows service $(serviceName)",

--- a/WinServices/StopWindowsService/task.json
+++ b/WinServices/StopWindowsService/task.json
@@ -13,7 +13,7 @@
 	"version": {
 		"Major": "1",
 		"Minor": "1",
-		"Patch": "0"
+		"Patch": "1"
 	},
 	"minimumAgentVersion": "1.83.0",
 	"instanceNameFormat": "Stop windows service $(serviceName)",

--- a/WinServices/vss-extension.json
+++ b/WinServices/vss-extension.json
@@ -3,7 +3,7 @@
 	"id": "jungit-winservices",
 	"name": "Windows Services Toolbox",
 	"description": "Toolbox of tasks to manage windows services",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"publisher": "jungeriusit",
 	"public": true, 
 	"baseUri": "https://github.com/chrisism/",


### PR DESCRIPTION
I found a bug in my implementation, where the parameter **-StartupType AutomaticDelayedStart** only works on versions of powershell 6 or higher.

I made a new implementation to work on earlier versions of powershell.

I am generating a new pull request with this bug fix.

Could you generate a new version of the package on the marketplace, including bug fix?

Sorry for my bug.